### PR TITLE
Fix MeteoExtractor.java

### DIFF
--- a/crawlerEventi/nuove_tabelle.txt
+++ b/crawlerEventi/nuove_tabelle.txt
@@ -1,0 +1,54 @@
+create table meteo_comuni
+(
+  autoid         serial not null,
+  idcomune       text,
+  comune         text,
+  data           timestamp,
+  primavera      smallint,
+  estate         smallint,
+  autunno        smallint,
+  inverno        smallint,
+  sereno         smallint,
+  coperto        smallint,
+  poco_nuvoloso  smallint,
+  pioggia        smallint,
+  temporale      smallint,
+  nebbia         smallint,
+  neve           smallint,
+  temperatura    numeric,
+  velocita_vento numeric,
+  constraint meteo_comuni_pk
+    primary key (autoid),
+  constraint meteo_comuni_comuni_istat_fk
+    foreign key (idcomune) references comuni
+      on update cascade on delete cascade
+);
+
+alter table meteo_comuni
+  owner to postgres;
+
+create unique index meteo_comuni_autoid_uindex
+  on meteo_comuni (autoid);
+
+
+
+create table meteo_eventi
+(
+  autoid     serial  not null,
+  link       text,
+  titolo     text,
+  dataevento timestamp,
+  idevento   integer not null,
+  idmeteo    integer not null,
+  constraint meteo_eventi_pk
+    primary key (autoid),
+  constraint meteo_eventi_eventi_autoid_fk
+    foreign key (idevento) references eventi
+      on update cascade on delete cascade,
+  constraint meteo_eventi_meteo_comuni_autoid_fk
+    foreign key (idmeteo) references meteo_comuni
+      on update cascade on delete cascade
+);
+
+alter table meteo_eventi
+  owner to postgres;

--- a/crawlerEventi/src/crawlerTaccodiBacco/LinkExtractor.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/LinkExtractor.java
@@ -32,6 +32,12 @@ public class LinkExtractor {
 
 	public static void getLinks(String startDat, String endDat) throws ParseException, IOException, SQLException{
 		Connection connDb = null;
+
+		//DEBUG_CODE
+        int newLinks = 0;
+		int oldLinks = 0;
+        int totalLinks = 0;
+
 		try
 	    {
 	    	Class.forName("org.postgresql.Driver");
@@ -60,9 +66,9 @@ public class LinkExtractor {
 		
 		
 			 String link = "https://iltaccodibacco.it/puglia/eventi/"+formatter.format(date)+"//";
-			
+
+
 			 URL url = new URL(link);
-	
 			 URLConnection conn = url.openConnection();
 			 conn.setRequestProperty("User-Agent","Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 Safari/537.36");
 			 conn.setRequestProperty("Accept","text/html");
@@ -85,14 +91,16 @@ public class LinkExtractor {
 		    	 String linkPage = blocco.childNode(1).childNode(1).attr("href");
 		    	 String titolo = blocco.childNode(1).childNode(1).childNode(0).outerHtml();
 		    	 if(!linkPage.equals(" ") && !linkPage.equals("") ){
-		    		 
 		    		 String check = "SELECT * from links where data_ev = ? AND link =? AND titolo = ?";
 		    		 PreparedStatement st1 = connDb.prepareStatement(check);
 			    	 st1.setDate(1, new java.sql.Date(date.getTime()));
 			    	 st1.setString(2, linkPage);
 			    	 st1.setString(3, titolo);
 			    	 ResultSet rs = st1.executeQuery();
-		    		 
+
+                     //DEBUG_CODE
+                     oldLinks++;
+
 			    	 if(!rs.next()){
 				    	 String q = "INSERT INTO links(data_ev,link,titolo) VALUES (?,?,?)";
 				    	 PreparedStatement st = connDb.prepareStatement(q);
@@ -100,14 +108,25 @@ public class LinkExtractor {
 				    	 st.setString(2, linkPage);
 				    	 st.setString(3, titolo);
 				    	 st.execute();
+
+                         //DEBUG_CODE
+                         newLinks++;
+
 			    	 }
-			    	 
-			    	 
+
+                     //DEBUG_CODE
+                     totalLinks++;
 		    	 }
 		     }
-		     
-	        
+
 		}
+
+		//DEBUG_CODE
+        oldLinks = oldLinks - newLinks;
+        System.out.println("New links inserted: " + newLinks);
+        System.out.println("Links already in db: " + oldLinks);
+        System.out.println("TOTAL links found: " + totalLinks);
+
 		connDb.close();
 	}
 	
@@ -121,6 +140,10 @@ public class LinkExtractor {
 		String startDat = formmat1.format(ldt.minusDays(7));
 		
 		String endDat = formmat1.format(ldt.plusMonths(6));
+
+
+		//DEBUG_CODE
+		System.out.println("LinkExtractor.java: finding event from " + startDat + " to " + endDat + " ...");
 		
 		try {
 			getLinks(startDat, endDat);

--- a/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
@@ -86,13 +86,13 @@ public class MeteoExtractor {
 				 String nomeMese = iniziale.toUpperCase() + finale.toLowerCase();
 
 				 //METEO_CODE
-				 int idMeteo = checkMeteoDb(comune, a, connDb);
+				 int idMeteo = checkMeteoDb(idComune, a, connDb);
 				 if (idMeteo != -1){
 				     AddMeteoEvento(link,rs0.getString("titolo"),a,rs0.getInt("autoid"),idMeteo,connDb);
                  }
 				 else {
                      String linkMeteo = "https://www.ilmeteo.it/portale/archivio-meteo/" + URLEncoder.encode(comune) + "/" + (a.getYear() + 1900) + "/" + nomeMese + "/" + a.getDate();
-                     //getMeteoData(linkMeteo,link,rs0.getString("titolo"), a, connDb);
+                     getMeteoData(linkMeteo,idComune, a, connDb);
                  }
 			 }else {
 			 
@@ -124,7 +124,8 @@ public class MeteoExtractor {
 		System.out.println("Number of meteo calls: " + callsCount);
 	}
 	
-	public static void getMeteoData(String linkMeteo, String linkEvento, String titolo, Date dataevento, Connection connDb) throws Exception  {
+	//public static void getMeteoData(String linkMeteo, String linkEvento, String titolo, Date dataevento, Connection connDb) throws Exception  {
+    public static void getMeteoData(String linkMeteo,String idComune, Date dataevento, Connection connDb) throws Exception  {
 		 try {
 			 URL url = new URL(linkMeteo);
 				System.out.println(linkMeteo);
@@ -208,36 +209,32 @@ public class MeteoExtractor {
 			}
 		     
 			//Inserisci nel db
-	    	 String check = "SELECT * from meteo where link =? AND titolo = ? AND dataevento = ?";
+	    	 String check = "SELECT * from meteo_2 where idcomune = ? AND data = ?";
 	    	 PreparedStatement st1 = connDb.prepareStatement(check);
-	    	 st1.setString(1, linkEvento);
-	    	 st1.setString(2, titolo);
-	    	 st1.setDate(3, new java.sql.Date(dataevento.getTime()));
+	    	 st1.setString(1, idComune);
+	    	 st1.setDate(2, new java.sql.Date(dataevento.getTime()));
 	    	 ResultSet rs = st1.executeQuery();
 	    	
 	    	 if(!rs.next()){
 			
-	    		 String q = "INSERT INTO meteo(link,titolo,dataevento,primavera,estate,autunno,inverno,sereno,coperto,poco_nuvoloso,pioggia,temporale,nebbia,neve,temperatura,velocita_vento) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
+	    		 String q = "INSERT INTO meteo_2(idcomune,data,primavera,estate,autunno,inverno,sereno,coperto,poco_nuvoloso,pioggia,temporale,nebbia,neve,temperatura,velocita_vento) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)";
 	    		 PreparedStatement st2 = connDb.prepareStatement(q);
-		    	 st2.setString(1, linkEvento);
-		    	 st2.setString(2, titolo);
-		    	 st2.setDate(3, new java.sql.Date(dataevento.getTime()));
-		    	 st2.setInt(4, primavera);
-		    	 st2.setInt(5, estate);
-		    	 st2.setInt(6, autunno);
-		    	 st2.setInt(7, inverno);
-		    	 st2.setInt(8, sereno);
-		    	 st2.setInt(9, coperto);
-		    	 st2.setInt(10, poco_nuv);
-		    	 st2.setInt(11, pioggia);
-		    	 st2.setInt(12, temporale);
-		    	 st2.setInt(13, nebbia);
-		    	 st2.setInt(14, neve);
-		    	 st2.setInt(15, tempMedia);
-		    	 st2.setInt(16, ventoMedio);
+		    	 st2.setString(1, idComune);
+		    	 st2.setDate(2, new java.sql.Date(dataevento.getTime()));
+		    	 st2.setInt(3, primavera);
+		    	 st2.setInt(4, estate);
+		    	 st2.setInt(5, autunno);
+		    	 st2.setInt(6, inverno);
+		    	 st2.setInt(7, sereno);
+		    	 st2.setInt(8, coperto);
+		    	 st2.setInt(9, poco_nuv);
+		    	 st2.setInt(10, pioggia);
+		    	 st2.setInt(11, temporale);
+		    	 st2.setInt(12, nebbia);
+		    	 st2.setInt(13, neve);
+		    	 st2.setInt(14, tempMedia);
+		    	 st2.setInt(15, ventoMedio);
 		    	 st2.execute();
-		    	 
-		    	
 	    	 }
 			
 	     

--- a/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
@@ -150,13 +150,17 @@ public class MeteoExtractor {
                 System.out.println("Processed events: " + eventsProcessed + " ...");
                 System.out.println("Number of weather calls made: " + callsCount + " ...");
             }
+            //-----------------
+
             //Thread.sleep(5000);
 		}
 		connDb.close();
+        //DEBUG_CODE
         System.out.println("TOTAL number of events processed: " + eventsProcessed);
 		System.out.println("TOTAL number of weather calls: " + callsCount);
         System.out.println("TOTAL number of weather errors detected: " + errorsFound);
         System.out.println("TOTAL number of istat code errors detected: " + istatErrorsFound);
+        //---------------------
 	}
 	
 	//public static void getMeteoData(String linkMeteo, String linkEvento, String titolo, Date dataevento, Connection connDb) throws Exception  {

--- a/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/MeteoExtractor.java
@@ -86,8 +86,9 @@ public class MeteoExtractor {
 				 String nomeMese = iniziale.toUpperCase() + finale.toLowerCase();
 
 				 //METEO_CODE
+                 String idComune = getIstatDb(comune,a,connDb);
 				 int idMeteo = checkMeteoDb(idComune, a, connDb);
-				 if (idMeteo != -1){
+				 if (idMeteo != -1 && idComune != null){
 				     AddMeteoEvento(link,rs0.getString("titolo"),a,rs0.getInt("autoid"),idMeteo,connDb);
                  }
 				 else {
@@ -247,11 +248,10 @@ public class MeteoExtractor {
 
 
 
-    //Controlla che il comune abbia un codice istat e controlla se il meteo per la città e data selezionata sia già stato estratto
-    //se non è stato ancora estratto, restituisce -1, altrimenti restituisce l'id del meteo trovato.
-	public static int checkMeteoDb(String comune, Date data, Connection connDb) throws Exception{
-        int idMeteoFound = -1;
-        String istat;
+	//Controlla che il comune abbia un codice istat
+    public static String getIstatDb(String comune, Date data, Connection connDb) throws Exception {
+        String istatComuneFound = null;
+
         try {
 
             //Controlla codice istat partendo da nome comune
@@ -260,18 +260,34 @@ public class MeteoExtractor {
             statement.setString(1, comune);
             ResultSet rs = statement.executeQuery();
 
-            if(!rs.next()){ throw new Exception("Codice istat del comune " + comune + " non trovato.");}
-            else{istat = rs.getString("istat");}
-            System.out.println("codice istat di " + comune + ": " + istat);
+            if (!rs.next()) {
+                throw new Exception("Codice istat del comune " + comune + " non trovato.");
+            } else {
+                istatComuneFound = rs.getString("istat");
+            }
+            System.out.println("codice istat di " + comune + ": " + istatComuneFound);
+        }catch(Exception e) {error = true; e.printStackTrace();}
+
+
+        return istatComuneFound;
+    }
+
+
+    //Controlla se il meteo per la città e data selezionata sia già stato estratto
+    //se non è stato ancora estratto, restituisce -1, altrimenti restituisce l'id del meteo trovato.
+	public static int checkMeteoDb(String idComune, Date data, Connection connDb) throws Exception{
+        int idMeteoFound = -1;
+        String istat;
+        try {
 
             //Controlla se è presente gia' il meteo per comune e data selezionata
             String checkMeteo = "SELECT autoid from meteo_2 where idcomune = ? AND data = ?";
             PreparedStatement statement2 = connDb.prepareStatement(checkMeteo);
-            statement2.setString(1, istat);
+            statement2.setString(1, idComune);
             statement2.setDate(2, new java.sql.Date(data.getTime()));
             ResultSet rs2 = statement2.executeQuery();
 
-            if(!rs2.next()){System.out.println("Meteo per " + istat + " non trovato.");}
+            if(!rs2.next()){System.out.println("Meteo per " + idComune + " non trovato.");}
             else{idMeteoFound = rs2.getInt("autoid");}
 
         }catch(Exception e) {error = true; e.printStackTrace();}

--- a/crawlerEventi/src/crawlerTaccodiBacco/Updater.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/Updater.java
@@ -42,7 +42,7 @@ public class Updater {
         System.out.println("Updater.java: processing w2v ...");
 
 		Core.eventsTow2v();
-		//MeteoExtractor.extractPastMeteoData();//<- Sistemare i duplicati e cercare una nuova fonte. ???
+		MeteoExtractor.extractPastMeteoData();//<- Sistemare i duplicati e cercare una nuova fonte. ???
 		//PrevisioniExtractor.extract7days();
 		//Converter.eventiTovec();
 

--- a/crawlerEventi/src/crawlerTaccodiBacco/Updater.java
+++ b/crawlerEventi/src/crawlerTaccodiBacco/Updater.java
@@ -31,15 +31,26 @@ public class Updater {
 		ResultSet rs0 = st0.executeQuery(query);
 		rs0.next();
 		Date last_up = rs0.getDate("last_update");
-		
+
+		//DEBUG_CODE
+		System.out.println("Updater.java: last update found: " + last_up.toString());
+
 		LinkExtractor.updateLinks(last_up);
 		EventExtractor.eventExtract();
+
+        //DEBUG_CODE
+        System.out.println("Updater.java: processing w2v ...");
+
 		Core.eventsTow2v();
 		//MeteoExtractor.extractPastMeteoData();//<- Sistemare i duplicati e cercare una nuova fonte. ???
 		//PrevisioniExtractor.extract7days();
 		//Converter.eventiTovec();
-		
-		
+
+        //DEBUG_CODE
+        System.out.println("Updater.java: w2v done");
+
+
+
 		//Save new update date to DB
 		String up = "UPDATE control set last_update = ?";
 		LocalDateTime ldt = LocalDateTime.now();
@@ -47,6 +58,9 @@ public class Updater {
 		pt.setDate(1, java.sql.Date.valueOf(ldt.toLocalDate()));
 		pt.execute();
 		connDb.close();
+
+        //DEBUG_CODE
+        System.out.println("Updater.java: db saved and closed");
 		
 	}
 }


### PR DESCRIPTION
+ Aggiunte due nuove tabelle `meteo_comuni e meteo_eventi` da utilizzare al posto della tabella `meteo`.
+ Aggiunto del codice (principalmente delle stampe su terminale e delle query di conteggio righe) per monitorare il progresso del crawler. Il codice è preceduto dal commento `//DEBUG_CODE` ed è stato inserito nei file `Updater.java, EventExtractor.java, LinkExtractor.java e MeteoExtractor.java`.
+ Il codice SQL delle nuove tabelle si trova nel file `nuove_tabelle.txt`.

Le nuove tabelle sono cosi formate:
### meteo_comuni 
_Questa tabella associa ad un comune/data il bollettino meteo della giornata._
Lista dei campi:
+ **autoid** (int, chiave primaria) - id della riga
+ **idcomune** (text, chiave esterna a comuni.istat) - id del comune
+ **comune** (text) - nome del comune, aggiunto per rendere piu' chiara la lettura della tabella
+ **data** (timestamp) - data per cui cercare il meteo relativo al comune
+ altri campi relativi al meteo (primavera, estate, temperatura, ecc.) 

### meteo_eventi
_Questa tabella associa ad ogni evento/data il bollettino meteo del corrispettivo comune/data in cui si terrà l'evento._
Lista dei campi:
+ **autoid** (int, chiave primaria) - id della riga
+ **link** (text) - link dell'evento
+ **titolo** (text) - titolo dell'evento
+ **dataevento** (timestamp) - data in cui si terrà l'evento
+ **idevento** (int, chiave esterna a eventi.autoid) - indica l'id dell'evento all'interno della tabella eventi
+ **idmeteo** (int, chiave esterna a meteo_comuni.autoid) - indica l'id che corrisponde al bollettino meteo per la giornata dell'evento, presente nella tabella meteo_comuni

Per quanto riguarda il funzionamento, anziché usare il nome del comune come chiave primaria ho usato il suo codice istat, quindi prima di cercare il meteo per un evento vado a cercare il codice istat che corrisponde al comune (in alcuni casi non ho trovato il codice, diciamo 5 casi su 400 eventi).
Una volta trovato il codice istat, vado a controllare se nella tabella meteo_comuni è già disponibile il bollettino meteo per la città e la data in cui si terrà l'evento, se il bollettino esiste allora utilizzo l'id di quella riga per l'inserimento in meteo_eventi. Se il bollettino non esiste, allora vado ad effettuare la chiamata al servizio meteo per reperire le informazioni.

Con questo approccio, sono state necessarie solo 200 chiamate al servizio meteo per analizzare 400 eventi (partendo con tabelle senza dati).

**NOTA:** La chiamata a `Converter.eventiTovec()` è ancora disattivata in quanto è necessario modificare la query che fa uso della vecchia tabella meteo. Non è stata ancora sistemata dato che bisogna modificare anche il codice e le tabelle per `PrevisioniExtractor`.